### PR TITLE
Don't crash on spawn error, call the callback instead

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@ function spawnLatexProcess(attempt, outputDirectory, outputLogs, callback){
 		cwd: outputDirectory,
 		env: env
 	});
+	pdflatex.on('error', callback);
 	
 	var outputLog = "", outputErr = "";
 	pdflatex.stdout.on("data", function(data){


### PR DESCRIPTION
Without this, there is no way for the caller to handle the exception in case of a missing pdflatex command.
